### PR TITLE
Fix install for non-sudo systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,1 +1,4 @@
-sudo install ./bin/release/mount /sbin/mount.tifs
+#!/usr/bin/env sh
+
+DOAS=$(which sudo || which doas)
+$DOAS install ./bin/release/mount /sbin/mount.tifs

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,2 @@
 #!/usr/bin/env sh
-
-DOAS=$(which sudo || which doas)
-$DOAS install ./bin/release/mount /sbin/mount.tifs
+install ./bin/release/mount /sbin/mount.tifs


### PR DESCRIPTION
While most Linux systems will have `sudo` installed, there is a minority that don't and to account for that I've added a small line to `install.sh` that attempts to use `doas` on systems that lack `sudo`.

It's worth noting that this is only a half fix, as this still relies on either `sudo` or `doas` being installed on the system. Usually invoking `doas`/`sudo` is left up to the end user, and I feel like that should be the case here.